### PR TITLE
Add internationalization support with English and Swahili

### DIFF
--- a/flutterapp/lib/core/config/locale_controller.dart
+++ b/flutterapp/lib/core/config/locale_controller.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LocaleController extends ChangeNotifier {
+  LocaleController({required SharedPreferences preferences}) : _preferences = preferences {
+    final code = _preferences.getString(_storageKey);
+    if (code != null && code.isNotEmpty) {
+      _locale = Locale(code);
+    }
+  }
+
+  static const _storageKey = 'app_locale';
+
+  final SharedPreferences _preferences;
+  Locale? _locale;
+
+  Locale? get locale => _locale;
+
+  Future<void> setLocale(Locale locale) async {
+    _locale = locale;
+    await _preferences.setString(_storageKey, locale.languageCode);
+    notifyListeners();
+  }
+
+  Future<void> useSystemLocale() async {
+    _locale = null;
+    await _preferences.remove(_storageKey);
+    notifyListeners();
+  }
+
+  bool isCurrentLocale(Locale locale) {
+    return _locale?.languageCode == locale.languageCode;
+  }
+}

--- a/flutterapp/lib/core/ui/language_menu.dart
+++ b/flutterapp/lib/core/ui/language_menu.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
+
+import '../config/locale_controller.dart';
+import '../utils/localization_extensions.dart';
+
+class LanguageMenu extends StatelessWidget {
+  const LanguageMenu({this.iconColor, super.key});
+
+  final Color? iconColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final localeController = context.watch<LocaleController>();
+    final l10n = context.l10n;
+    final currentCode = localeController.locale?.languageCode;
+
+    return PopupMenuButton<_LanguageSelection>(
+      tooltip: l10n.languageMenuTooltip,
+      icon: Icon(Icons.language_outlined, color: iconColor ?? Theme.of(context).colorScheme.onSurfaceVariant),
+      onSelected: (selection) async {
+        switch (selection) {
+          case _LanguageSelection.system:
+            await localeController.useSystemLocale();
+          case _LanguageSelection.english:
+            await localeController.setLocale(const Locale('en'));
+          case _LanguageSelection.swahili:
+            await localeController.setLocale(const Locale('sw'));
+        }
+      },
+      itemBuilder: (context) => <PopupMenuEntry<_LanguageSelection>>[
+        CheckedPopupMenuItem<_LanguageSelection>(
+          value: _LanguageSelection.system,
+          checked: currentCode == null,
+          child: Text(l10n.languageMenuSystem),
+        ),
+        CheckedPopupMenuItem<_LanguageSelection>(
+          value: _LanguageSelection.english,
+          checked: currentCode == 'en',
+          child: Text(l10n.languageMenuEnglish),
+        ),
+        CheckedPopupMenuItem<_LanguageSelection>(
+          value: _LanguageSelection.swahili,
+          checked: currentCode == 'sw',
+          child: Text(l10n.languageMenuSwahili),
+        ),
+      ],
+    );
+  }
+}
+
+enum _LanguageSelection { system, english, swahili }

--- a/flutterapp/lib/core/utils/localization_extensions.dart
+++ b/flutterapp/lib/core/utils/localization_extensions.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+extension LocalizationBuildContext on BuildContext {
+  AppLocalizations get l10n => AppLocalizations.of(this)!;
+}

--- a/flutterapp/lib/features/auth/presentation/login_screen.dart
+++ b/flutterapp/lib/features/auth/presentation/login_screen.dart
@@ -4,6 +4,8 @@ import 'package:provider/provider.dart';
 
 import '../../../core/exceptions/app_exception.dart';
 import '../../../core/ui/animated_background.dart';
+import '../../../core/ui/language_menu.dart';
+import '../../../core/utils/localization_extensions.dart';
 import 'session_controller.dart';
 
 class LoginScreen extends StatefulWidget {

--- a/flutterapp/lib/features/auth/presentation/login_screen.dart
+++ b/flutterapp/lib/features/auth/presentation/login_screen.dart
@@ -140,7 +140,7 @@ class _LoginScreenState extends State<LoginScreen> {
                             controller: _passwordController,
                             obscureText: !_passwordVisible,
                             decoration: InputDecoration(
-                              labelText: 'Password',
+                              labelText: l10n.loginPasswordLabel,
                               prefixIcon: const Icon(Icons.lock_outline),
                               suffixIcon: IconButton(
                                 icon: Icon(_passwordVisible ? Icons.visibility_off : Icons.visibility),
@@ -153,7 +153,7 @@ class _LoginScreenState extends State<LoginScreen> {
                             onFieldSubmitted: (_) => _submit(context),
                             validator: (value) {
                               if (value == null || value.isEmpty) {
-                                return 'Enter your password';
+                                return l10n.loginPasswordRequired;
                               }
                               return null;
                             },

--- a/flutterapp/lib/features/auth/presentation/login_screen.dart
+++ b/flutterapp/lib/features/auth/presentation/login_screen.dart
@@ -177,7 +177,7 @@ class _LoginScreenState extends State<LoginScreen> {
                                     width: 22,
                                     child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
                                   )
-                                : const Text('Sign in'),
+                                : Text(l10n.commonSignIn),
                           ),
                         ],
                       ),

--- a/flutterapp/lib/features/auth/presentation/login_screen.dart
+++ b/flutterapp/lib/features/auth/presentation/login_screen.dart
@@ -50,10 +50,17 @@ class _LoginScreenState extends State<LoginScreen> {
           const TopWaves(),
           const AnimatedParticlesBackground(),
           SafeArea(
-            child: Center(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-                child: ConstrainedBox(
+            child: Stack(
+              children: [
+                const Positioned(
+                  top: 12,
+                  right: 12,
+                  child: LanguageMenu(iconColor: Colors.white),
+                ),
+                Center(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+                    child: ConstrainedBox(
                   constraints: const BoxConstraints(maxWidth: 420),
                   child: AnimatedContainer(
                     duration: const Duration(milliseconds: 400),
@@ -173,10 +180,10 @@ class _LoginScreenState extends State<LoginScreen> {
                           ),
                         ],
                       ),
-                    ),
-                  ),
                 ),
-              ),
+              ],
+            ),
+          ),
             ),
           ),
         ],

--- a/flutterapp/lib/features/auth/presentation/login_screen.dart
+++ b/flutterapp/lib/features/auth/presentation/login_screen.dart
@@ -122,7 +122,7 @@ class _LoginScreenState extends State<LoginScreen> {
                             controller: _usernameController,
                             textInputAction: TextInputAction.next,
                             decoration: InputDecoration(
-                              labelText: 'Username',
+                              labelText: l10n.loginUsernameLabel,
                               prefixIcon: const Icon(Icons.person_outline),
                               filled: true,
                               fillColor: const Color(0xFFF4F7FB),
@@ -130,7 +130,7 @@ class _LoginScreenState extends State<LoginScreen> {
                             ),
                             validator: (value) {
                               if (value == null || value.trim().isEmpty) {
-                                return 'Enter your username';
+                                return l10n.loginUsernameRequired;
                               }
                               return null;
                             },

--- a/flutterapp/lib/features/auth/presentation/login_screen.dart
+++ b/flutterapp/lib/features/auth/presentation/login_screen.dart
@@ -109,7 +109,7 @@ class _LoginScreenState extends State<LoginScreen> {
                               ),
                               const SizedBox(height: 8),
                               Text(
-                                'Log in to coordinate inspections, capture field evidence, and deliver customer-ready reports.',
+                                l10n.loginSubtitle,
                                 textAlign: TextAlign.center,
                                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                                       color: const Color(0xFF4A6572),

--- a/flutterapp/lib/features/auth/presentation/login_screen.dart
+++ b/flutterapp/lib/features/auth/presentation/login_screen.dart
@@ -33,6 +33,7 @@ class _LoginScreenState extends State<LoginScreen> {
     final session = context.watch<SessionController>();
     final isLoading = session.isLoading;
     final error = session.error;
+    final l10n = context.l10n;
 
     return Scaffold(
       body: Stack(

--- a/flutterapp/lib/features/auth/presentation/login_screen.dart
+++ b/flutterapp/lib/features/auth/presentation/login_screen.dart
@@ -101,7 +101,7 @@ class _LoginScreenState extends State<LoginScreen> {
                               ),
                               const SizedBox(height: 16),
                               Text(
-                                'Fleet Inspection Portal',
+                                l10n.loginTitle,
                                 style: Theme.of(context).textTheme.headlineSmall?.copyWith(
                                       fontWeight: FontWeight.w700,
                                       color: const Color(0xFF22313F),

--- a/flutterapp/lib/features/inspections/presentation/inspector_home_screen.dart
+++ b/flutterapp/lib/features/inspections/presentation/inspector_home_screen.dart
@@ -47,6 +47,7 @@ class _InspectorHomeViewState extends State<_InspectorHomeView> {
   Widget build(BuildContext context) {
     return Consumer<InspectorDashboardController>(
       builder: (context, controller, _) {
+        final l10n = context.l10n;
         return Scaffold(
           appBar: AppBar(
             title: Text('Inspector • ${widget.profile.fullName}'),

--- a/flutterapp/lib/features/inspections/presentation/inspector_home_screen.dart
+++ b/flutterapp/lib/features/inspections/presentation/inspector_home_screen.dart
@@ -3,6 +3,8 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 import '../../../core/ui/animated_background.dart';
+import '../../../core/ui/language_menu.dart';
+import '../../../core/utils/localization_extensions.dart';
 import '../../auth/presentation/session_controller.dart';
 import '../data/checklist_blueprint.dart';
 import '../data/inspections_repository.dart';

--- a/flutterapp/lib/l10n/app_en.arb
+++ b/flutterapp/lib/l10n/app_en.arb
@@ -1,0 +1,9 @@
+{
+  "@@locale": "en",
+  "appTitle": "Fleet Inspection",
+  "appTitleShort": "Fleet Inspection",
+  "languageMenuTooltip": "Change language",
+  "languageMenuSystem": "System default",
+  "languageMenuEnglish": "English",
+  "languageMenuSwahili": "Kiswahili"
+}

--- a/flutterapp/lib/l10n/app_sw.arb
+++ b/flutterapp/lib/l10n/app_sw.arb
@@ -1,0 +1,9 @@
+{
+  "@@locale": "sw",
+  "appTitle": "Ukaguzi wa Magari",
+  "appTitleShort": "Ukaguzi wa Magari",
+  "languageMenuTooltip": "Badilisha lugha",
+  "languageMenuSystem": "Chaguo la mfumo",
+  "languageMenuEnglish": "Kiingereza",
+  "languageMenuSwahili": "Kiswahili"
+}

--- a/flutterapp/lib/main.dart
+++ b/flutterapp/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'core/api/api_client.dart';
 import 'core/config/app_config.dart';

--- a/flutterapp/lib/main.dart
+++ b/flutterapp/lib/main.dart
@@ -59,6 +59,7 @@ class AppRoot extends StatelessWidget {
         Provider<TokenStore>.value(value: tokenStore),
         Provider<ApiClient>.value(value: apiClient),
         Provider<OfflineQueueService>.value(value: offlineQueue),
+        ChangeNotifierProvider<LocaleController>.value(value: localeController),
         ProxyProvider2<ApiClient, OfflineQueueService, InspectionsRepository>(
           update: (_, api, queue, __) => InspectionsRepository(apiClient: api, offlineQueueService: queue),
         ),

--- a/flutterapp/lib/main.dart
+++ b/flutterapp/lib/main.dart
@@ -41,6 +41,7 @@ class AppRoot extends StatelessWidget {
     required this.tokenStore,
     required this.apiClient,
     required this.offlineQueue,
+    required this.localeController,
     super.key,
   });
 
@@ -48,6 +49,7 @@ class AppRoot extends StatelessWidget {
   final TokenStore tokenStore;
   final ApiClient apiClient;
   final OfflineQueueService offlineQueue;
+  final LocaleController localeController;
 
   @override
   Widget build(BuildContext context) {

--- a/flutterapp/lib/main.dart
+++ b/flutterapp/lib/main.dart
@@ -144,7 +144,10 @@ class _UnsupportedRoleScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Fleet Inspection')),
+      appBar: AppBar(
+        title: Text(context.l10n.appTitleShort),
+        actions: const [LanguageMenu()],
+      ),
       body: Center(
         child: Padding(
           padding: const EdgeInsets.all(24),
@@ -153,17 +156,20 @@ class _UnsupportedRoleScreen extends StatelessWidget {
             children: [
               const Icon(Icons.desktop_windows_outlined, size: 48),
               const SizedBox(height: 12),
-              Text('Hello ${profile.fullName}', style: Theme.of(context).textTheme.titleLarge),
+              Text(
+                context.l10n.unsupportedGreeting(profile.fullName),
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
               const SizedBox(height: 8),
-              const Text(
-                'Admin features are available on the web portal.\nPlease use the inspector or customer role in the app.',
+              Text(
+                context.l10n.unsupportedMessage,
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 16),
               FilledButton.icon(
                 onPressed: () => context.read<SessionController>().logout(),
                 icon: const Icon(Icons.logout),
-                label: const Text('Sign out'),
+                label: Text(context.l10n.commonSignOut),
               ),
             ],
           ),

--- a/flutterapp/lib/main.dart
+++ b/flutterapp/lib/main.dart
@@ -71,7 +71,10 @@ class AppRoot extends StatelessWidget {
         ),
       ],
       child: MaterialApp(
-        title: 'Fleet Inspection',
+        onGenerateTitle: (context) => context.l10n.appTitle,
+        locale: context.watch<LocaleController>().locale,
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
         theme: ThemeData(
           useMaterial3: true,
           colorScheme: ColorScheme.fromSeed(

--- a/flutterapp/lib/main.dart
+++ b/flutterapp/lib/main.dart
@@ -23,12 +23,15 @@ Future<void> main() async {
   final tokenStore = TokenStore();
   final apiClient = ApiClient(config: config, tokenStore: tokenStore);
   final offlineQueue = await OfflineQueueService.init();
+  final preferences = await SharedPreferences.getInstance();
+  final localeController = LocaleController(preferences: preferences);
 
   runApp(AppRoot(
     config: config,
     tokenStore: tokenStore,
     apiClient: apiClient,
     offlineQueue: offlineQueue,
+    localeController: localeController,
   ));
 }
 

--- a/flutterapp/lib/main.dart
+++ b/flutterapp/lib/main.dart
@@ -8,6 +8,7 @@ import 'core/config/app_config.dart';
 import 'core/config/locale_controller.dart';
 import 'core/storage/offline_queue.dart';
 import 'core/storage/token_store.dart';
+import 'core/ui/language_menu.dart';
 import 'core/utils/localization_extensions.dart';
 import 'features/auth/data/auth_repository.dart';
 import 'features/auth/presentation/login_screen.dart';

--- a/flutterapp/lib/main.dart
+++ b/flutterapp/lib/main.dart
@@ -5,8 +5,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'core/api/api_client.dart';
 import 'core/config/app_config.dart';
+import 'core/config/locale_controller.dart';
 import 'core/storage/offline_queue.dart';
 import 'core/storage/token_store.dart';
+import 'core/utils/localization_extensions.dart';
 import 'features/auth/data/auth_repository.dart';
 import 'features/auth/presentation/login_screen.dart';
 import 'features/auth/presentation/session_controller.dart';

--- a/flutterapp/pubspec.yaml
+++ b/flutterapp/pubspec.yaml
@@ -10,6 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   cupertino_icons: ^1.0.8
   http: ^1.1.0
   shared_preferences: ^2.2.2
@@ -43,6 +45,7 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
+  generate: true
   uses-material-design: true
   assets:
     - assets/images/


### PR DESCRIPTION
## Changes Made

### New Files Added
- **LocaleController** (`lib/core/config/locale_controller.dart`)
  - Manages app locale state using ChangeNotifier
  - Persists locale selection in SharedPreferences
  - Supports setting specific locale or using system default

- **LanguageMenu** (`lib/core/ui/language_menu.dart`)
  - Popup menu widget for language selection
  - Supports System default, English, and Swahili options
  - Shows current selection with checkmarks

- **Localization Extensions** (`lib/core/utils/localization_extensions.dart`)
  - BuildContext extension for easy access to AppLocalizations

- **Localization Files**
  - `lib/l10n/app_en.arb` - English translations
  - `lib/l10n/app_sw.arb` - Swahili translations

### Modified Files
- **main.dart**
  - Added LocaleController provider setup
  - Configured MaterialApp with localization delegates and supported locales
  - Updated UnsupportedRoleScreen to use localized strings

- **login_screen.dart**
  - Added LanguageMenu to top-right corner
  - Replaced hardcoded strings with localized versions
  - Updated form labels and validation messages

- **inspector_home_screen.dart**
  - Added localization extension import

- **pubspec.yaml**
  - Added flutter_localizations dependency
  - Enabled code generation with `flutter: generate: true`

### Localization Support
- Added support for English (en) and Swahili (sw) languages
- Implemented persistent locale selection
- Added language switcher UI component
- Converted login screen text to use localized strings

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9faf300d364740f7a0c00432e6c46aad/swoosh-works)

👀 [Preview Link](https://9faf300d364740f7a0c00432e6c46aad-swoosh-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9faf300d364740f7a0c00432e6c46aad</projectId>-->
<!--<branchName>swoosh-works</branchName>-->